### PR TITLE
added two options to build file to simplify debugging InflectionCompiler/ProxyGenerator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,3 @@
-// For debugging:
-// '-agentlib:jdwp=transport=dt_socket,address=9009,server=y,suspend=y'
-
 plugins {
     id "java"
     id "maven"
@@ -69,11 +66,21 @@ antlr4 {
 compileJava.dependsOn antlr4
 sourceSets.main.java.srcDirs += "$buildDir/generated/antlr"
 
+// Debugging
+def debugInflectionCompiler="";
+def debugProxyGenerator="";
+if (this.hasProperty("debugInflectionCompilerAddress")) {
+    debugInflectionCompiler="-agentlib:jdwp=transport=dt_socket,address=$debugInflectionCompilerAddress,server=y,suspend=y";	
+}
+if (this.hasProperty("debugProxyGeneratorAddress")) {
+    debugProxyGenerator="-agentlib:jdwp=transport=dt_socket,address=$debugProxyGeneratorAddress,server=y,suspend=y";	
+}
+
 // Inflect test model
 task( compileTestTaxonomiesInflection, dependsOn: compileTestModelJava, type: JavaExec ) {
 	main = "ch.liquidmind.inflection.compiler.InflectionCompiler"
 	classpath = sourceSets.main.runtimeClasspath + sourceSets.testModel.runtimeClasspath
-	jvmArgs '-ea'
+	jvmArgs '-ea', debugInflectionCompiler
 	args "${buildDir}/resources/testModel", "BOOTSTRAP", "src/test/resources/ch/liquidmind/inflection/test/model/TestModel.inflect"
 }
 
@@ -85,7 +92,7 @@ compileTestTaxonomiesInflection.doFirst {
 task( proxifyTestTaxonomies, dependsOn: compileTestTaxonomiesInflection, type: JavaExec ) {
 	main = "ch.liquidmind.inflection.proxy.ProxyGenerator"
 	classpath = sourceSets.main.runtimeClasspath + sourceSets.testModel.runtimeClasspath
-	jvmArgs '-ea'
+	jvmArgs '-ea', debugProxyGenerator
 	args "${buildDir}/generated/inflection",
 	"ch.liquidmind.inflection.test.model.FullTaxonomy",
 	"ch.liquidmind.inflection.test.model.UseCase1",


### PR DESCRIPTION
I use this to debug the ProxyGenerator or the InflectionCompiler, you may find it useful.
Simply start build with optional parameters for debug port to activate debugging:

```
gradle clean build -PdebugInflectionCompilerAddress=9009 -PdebugProxyGeneratorAddress=8000
```
