### PR TITLE
Compiler should handle files with newline from a different os

### DIFF
--- a/src/main/java/ch/liquidmind/inflection/compiler/CompilationUnit.java
+++ b/src/main/java/ch/liquidmind/inflection/compiler/CompilationUnit.java
@@ -73,7 +73,7 @@ public class CompilationUnit
 			if ( sourceFileContent == null )
 			{
 				String sourceFileAsString = tokens.getTokenSource().getInputStream().toString();
-				sourceFileContent = sourceFileAsString.split( System.lineSeparator() );
+				sourceFileContent = sourceFileAsString.split( "\r?\n|\r" );
 			}
 			
 			return sourceFileContent;


### PR DESCRIPTION
e.g. when I am using UTF-8/Unix line endings files within Eclipse, the compiler cannot handle generating  a fault message using System.lineSeparator(), an IndexOutOfBoundsException is thrown.
